### PR TITLE
store result in memory

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -8,10 +8,7 @@ return [
      * can use multiple stores at the same time.
      */
     'result_stores' => [
-        Spatie\Health\ResultStores\JsonFileHealthResultStore::class => [
-            'disk' => 'local',
-            'path' => 'health.json',
-        ],
+        Spatie\Health\ResultStores\InMemoryHealthResultStore::class,
     ],
 
     /*


### PR DESCRIPTION
Do we really need storage 'in-file'?
The health.json file is missing at first deployment and could be giving issues when using in combination with statamic-health package.